### PR TITLE
Set “this” to be the configuration object for a custom render method.

### DIFF
--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -49,7 +49,7 @@ var registerServices = function(app, configs) {
 
             util.log('Registering', method.toUpperCase(), 'service at', config.path);
 
-            app[method](config.path, config.callback.bind(config), config.render);
+            app[method](config.path, config.callback.bind(config), config.render.bind(config));
         });
     }
 };


### PR DESCRIPTION
This change allows a custom render method to easily access its configuration object.
