### PR TITLE
Add requireParameters config option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 _site
+node_modules

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This is where dyson comes in. Get a full fake server for your application up and
 * Includes dummy image generator
     * Use any external or local image service (included)
     * Supports base64 encoded image strings
+* Supports required parameter validation
 
 [![Build Status](https://travis-ci.org/webpro/dyson.png)](https://travis-ci.org/webpro/dyson)
 

--- a/dummy/get/require-parameter.js
+++ b/dummy/get/require-parameter.js
@@ -1,0 +1,16 @@
+var g = require('dyson-generators');
+
+module.exports = {
+	path: '/requirepara',
+  requireParameters: ["client_id"],
+	template: {
+		id: g.id,
+        name: g.name,
+        address: {
+            city: g.address.city,
+            zipUS: g.address.zipUS
+        },
+        time: g.time.byQuarter,
+        lorem: g.lorem.short,
+    }
+};

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -2,6 +2,7 @@ var loader = require('./loader'),
     defaults = require('./defaults'),
     proxy = require('./proxy'),
     util = require('./util'),
+    requireParameter = require('./parameter'),
     cors = require('cors'),
     express = require('express'),
     path = require('path');
@@ -42,6 +43,7 @@ var initExpress = function(port) {
     return app;
 };
 
+
 // Register middleware to Express as service for each config (as in: `app.get(config.path, config.callback);`)
 
 var registerServices = function(app, options, configs) {
@@ -52,7 +54,7 @@ var registerServices = function(app, options, configs) {
 
             util.log('Registering', method.toUpperCase(), 'service at', config.path);
 
-            app[method](config.path, config.callback.bind(config), config.render.bind(config));
+            app[method](config.path, requireParameter.bind(config), config.callback.bind(config), config.render.bind(config));
         });
     }
 

--- a/lib/parameter.js
+++ b/lib/parameter.js
@@ -1,0 +1,22 @@
+var _ = require('lodash');
+
+module.exports = function(req, res, next){
+  var config = this,
+      missingParameters = [];
+
+  // check if it's need require parameters
+  if (!_.isEmpty(config.requireParameters)) {
+    _(config.requireParameters).forEach(function(p){
+      if (_.isEmpty(req.body[p]) && _.isEmpty(req.query[p])) {
+        missingParameters.push(p);
+      }
+    });
+
+    // check missing parameters
+    if (missingParameters.length > 0) {
+      res.status(400).send({"error": "Required parameters(" + missingParameters.join(',') + ") not found."});
+    }
+  }
+
+  next();
+};

--- a/test/dyson.integration.js
+++ b/test/dyson.integration.js
@@ -48,6 +48,9 @@ describe('dyson', function() {
                 }, {
                     path: '/combined/:id',
                     template: {}
+                }, {
+                    path: '/require-para',
+                    requireParameters: ['name']
                 }]
             };
 
@@ -109,14 +112,27 @@ describe('dyson', function() {
 
         });
 
+
         it('should respond with a 204 for an OPTIONS request', function(done) {
 
             request(app).options('/').expect(204).end(function(err, res) {
                 res.headers['access-control-allow-methods'].should.equal('GET,HEAD,PUT,POST,DELETE');
                 res.headers['access-control-allow-credentials'].should.equal('true');
-				// The next actual value is 'undefined', should be req.header('Origin') (probably an issue with supertest)
-				// res.headers['access-control-allow-origin'].should.equal('*');
+                // The next actual value is 'undefined', should be req.header('Origin') (probably an issue with supertest)
+                // res.headers['access-control-allow-origin'].should.equal('*');
                 done();
+            });
+
+        });
+
+        it('should respond with 400 bad request if required parameter not found', function(done) {
+            request(app).get('/require-para').expect(400).end(function(err, res) {
+                res.body.error.should.include("(name) not found");
+
+                // with required parameter
+                request(app).get('/require-para?name=Tim').expect(200).end(function(err, res) {
+                    done();
+                });
             });
 
         });


### PR DESCRIPTION
Add `requireParameters` config option, return 400 bad request if required validation failed.

``` javascript
config = {
   path: "/require-para",
   requireParameters: ['name']
}
```

``` javascript
GET /require-para
// response
400 {error: "Required parameters(name) not found"}
```

Hope I am not the only one who need this feature, thanks!
