### PR TITLE
Fixing lodash/underscore bug with templates that use length field

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -78,19 +78,22 @@ var setValues = function(template, params, scope) {
     return when.promise(function(resolve, reject, notify) {
 
         var promises = [],
-            obj = Object.create(template);
+            obj = Object.create(template),
+            key = value = '';
 
-        _.each(template, function(value, key) {
+        for (key in template) {
+            if (template.hasOwnProperty(key)) {
+                value = template[key];
+                obj[key] = _.isFunction(value) ? value.apply(scope || obj, params) : _.isPlainObject(value) ? setValues(value, params, obj) : value;
 
-            obj[key] = _.isFunction(value) ? value.apply(scope || obj, params) : _.isPlainObject(value) ? setValues(value, params, obj) : value;
-
-            if(when.isPromiseLike(obj[key])) {
-                promises.push(obj[key]);
-                obj[key].then(function(value) {
-                    obj[key] = value;
-                });
+                if(when.isPromiseLike(obj[key])) {
+                    promises.push(obj[key]);
+                    obj[key].then(function(value) {
+                        obj[key] = value;
+                    });
+                }
             }
-        });
+        };
 
         when.all(promises).then(function() {
             resolve(obj);


### PR DESCRIPTION
There's a known bug in some underscore functions that doesn't works with fields "length" (More details here: https://github.com/jashkenas/underscore/issues/1590).

Dyson used `_.each` to parse the templates, so if we had a template with field called **length**, it returns an empty response.

To simulate this behavior, just add it to some template.

``` javascript
module.exports = {
  path: "/bug",
  template: {
    "id": 5,
    "width": 10,
    "length": 10
  }
}
```

This PR fix this, substituing `_.each` for vanilla javascript object iteration
