### PR TITLE
include the request method to response log message

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -43,7 +43,7 @@ var generate = function(req, res, next) {
                 return !service.container ? data : setValues(_.result(service, 'container'), [params, query, data], service);
             }).then(function(data) {
                 res.body = cache[path] = data;
-                util.log('Resolving response for', path);
+                util.log('Resolving response for', req.method, path);
                 next();
             });
 
@@ -53,7 +53,7 @@ var generate = function(req, res, next) {
 
                 res.body = cache[path] = data;
 
-                util.log('Resolving response for:', path, '(multiRequest)');
+                util.log('Resolving response for:', req.method, path, '(multiRequest)');
 
                 next();
 
@@ -62,7 +62,7 @@ var generate = function(req, res, next) {
 
     } else {
 
-        util.log('Resolving response for', path, '(cached)');
+        util.log('Resolving response for', req.method, path, '(cached)');
 
         res.body = cache[path];
 


### PR DESCRIPTION
Today the log don't show the http verb of the request, this PR fixes that :smiley: 

``` log
Resolving response for PUT /services/quote-requests/1
Resolving response for GET /services/quote-requests/1
Resolving response for GET /services/quote-requests/1/responses
```