### PR TITLE
should support top level array for templates when not a collection

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -32,7 +32,7 @@ var generate = function(req, res, next) {
 
             } else {
 
-                var size = typeof service.size === 'function' ? service.size.apply(service, [params, query, body, cookies]) : service.size;
+                var size = _.isFunction(service.size) ? service.size.apply(service, [params, query, body, cookies]) : service.size;
 
                 promise = when.map(_.times(parseInt(size, 10)), function() {
                     return setValues(template, [params, query, body, cookies]);
@@ -78,7 +78,7 @@ var setValues = function(template, params, scope) {
     return when.promise(function(resolve, reject, notify) {
 
         var promises = [],
-            obj = Object.create(template),
+            obj = _.isArray(template)?[]:Object.create(template),
             key,
             value;
 

--- a/test/dyson.response.spec.js
+++ b/test/dyson.response.spec.js
@@ -37,11 +37,22 @@ describe('dyson.response', function() {
             };
 
             configDefaults.setValues(template).then(function(actual) {
-
                 _.isEqual(actual, expected).should.equal(true);
                 done();
 
             });
+        });
+
+        it('should return an array', function(done) {
+            var template = [function(){return "my function";},2,3];
+            var expected = ["my function", 2,3];
+
+            configDefaults.setValues(template).then(function(actual) {
+                _.isArray(actual).should.equal(true);
+                _.isEqual(actual, expected).should.equal(true);
+                done();
+
+            }); 
         });
 
         it('should parse template objects iteratively', function(done) {


### PR DESCRIPTION
when we want to "hardcode"  a collection, the toplevel value of `template` is an array. However, `Object.create` will not make the right prototype and only return a bar object. We want to make sure to get an array back at the end.