### PR TITLE
Added method config file proxy property for easy bypassing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The default values for the configuration objects:
 ``` javascript
 {
     cache: true,
+    proxy: false,
     size: function() {
         return _.random(2,10);
     },
@@ -95,6 +96,7 @@ The default values for the configuration objects:
 ```
 
 * `cache:true` means that multiple requests to the same path will result in the same response
+* `proxy:false` means that requests to this file can be skipped and sent to the configured proxy
 * `size:function` is the number of objects in the collection
 * `collection:true` will return a collection
 * `callback:function`

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -6,6 +6,7 @@ var defaults = {},
 
 defaults.get = defaults.post = defaults.put = defaults.delete = {
     cache: false,
+    proxy: false,
     size: function() {
         return _.random(2, 10);
     },

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -54,9 +54,13 @@ var registerServices = function(app, options, configs) {
 
         configs[method].forEach(function(config) {
 
-            util.log('Registering', method.toUpperCase(), 'service at', config.path);
+            if (options.proxy && config.proxy) { // Allows each config file to be bypassed without removing it
+                util.log('Proxying...', method.toUpperCase(), 'service at', config.path);
+            } else {
+                util.log('Registering', method.toUpperCase(), 'service at', config.path);
+                app[method](config.path, requireParameter.bind(config), config.callback, config.render);
+            }
 
-            app[method](config.path, requireParameter.bind(config), config.callback, config.render);
         });
     }
 


### PR DESCRIPTION
We have had a use case where we are using dyson in order to develop functionality but whilst we are still waiting on the real API to be completed. It is useful to be able to proxy endpoints selectively without getting rid of the file - incase the endpoint becomes broken and we need it back again for development.