### PR TITLE
Read directories recursively. Add support for PATCH requests.

### DIFF
--- a/dummy/get/sub/dummy.js
+++ b/dummy/get/sub/dummy.js
@@ -1,0 +1,11 @@
+module.exports = {
+  path: '/dummy-two',
+  proxy: false,
+  template: {
+    id: function(params) {
+      return params.id || 1;
+    },
+    name: 'Dummy two',
+    status: 'OK'
+  }
+};

--- a/dummy/get/sub/subsub/dummy.js
+++ b/dummy/get/sub/subsub/dummy.js
@@ -1,0 +1,11 @@
+module.exports = {
+  path: '/dummy-three',
+  proxy: false,
+  template: {
+    id: function(params) {
+      return params.id || 1;
+    },
+    name: 'Dummy three',
+    status: 'OK'
+  }
+};

--- a/dummy/post/sub/dummy.js
+++ b/dummy/post/sub/dummy.js
@@ -1,0 +1,9 @@
+var generateResponse = function(req, res, next) {
+    res.body = req.body;
+    next();
+};
+
+module.exports = {
+    path: '/dummy-two',
+    callback: generateResponse
+};

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -2,9 +2,9 @@ var response = require('./response'),
     _ = require('lodash');
 
 var defaults = {},
-    methods = ['get', 'post', 'put', 'delete'];
+    methods = ['get', 'post', 'put', 'delete', 'patch'];
 
-defaults.get = defaults.post = defaults.put = defaults.delete = {
+defaults.get = defaults.post = defaults.put = defaults.delete = defaults.patch = {
     cache: false,
     proxy: undefined,
     size: function() {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -19,27 +19,58 @@ var load = function(configDir) {
 
     });
 
-    return configs;
+  return configs;
 };
 
+/**
+ * Recursively walk through directories synchronously
+ * @param dir
+ * @param done
+ */
+var walkSync = function(dir, done) {
+  var results, list, i = 0, file, stat;
+  results = [];
+  list = fs.readdirSync(dir);
+  (function next() {
+    // Get next file
+    file = list[i++];
+    // No more files
+    if (!file) {
+      done(null, results);
+      return results;
+    }
+    // Create file path
+    file = dir + '/' + file;
+    stat = fs.statSync(file);
+    // If it's a directory, go through this process again
+    if (stat && stat.isDirectory()) {
+      walkSync(file, function(err, res) {
+        results = results.concat(res);
+        next();
+      });
+    // If not, just
+    } else {
+      results.push(file);
+      next();
+    }
+  })();
+};
+
+/**
+ * Walk through each top level directory (get, post, etc), find all subdirectories, require all files
+ * @param dir
+ * @returns {Array}
+ */
 var requireDir = function(dir) {
 
-    if(!(fs.existsSync(dir) && fs.statSync(dir).isDirectory())) {
-        return;
-    }
-
-    return fs.readdirSync(dir).map(function(element) {
-
-        if(element[0] === '.' || !/\.js$/i.test(element)) {
-            return;
-        }
-
-        var file = path.join(dir, element),
-            stats = fs.statSync(file);
-
-        return stats.isFile() ? require(file) : false;
-
+  var requireResults = [];
+  // Recursively walk through all subdirectories and include necessary files
+  walkSync(dir, function (err, results) {
+    results.map(function (file) {
+      requireResults.push(require(file));
     });
+  });
+  return requireResults;
 };
 
 module.exports = {

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,7 +4,7 @@ var _ = require('lodash'),
 
 var load = function(configDir) {
 
-    var methods = ['get', 'post', 'put', 'delete'],
+    var methods = ['get', 'post', 'put', 'delete', 'patch'],
         configs = {},
         methodConfigs,
         methodDir;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -30,30 +30,34 @@ var load = function(configDir) {
 var walkSync = function(dir, done) {
   var results, list, i = 0, file, stat;
   results = [];
-  list = fs.readdirSync(dir);
-  (function next() {
-    // Get next file
-    file = list[i++];
-    // No more files
-    if (!file) {
-      done(null, results);
-      return results;
-    }
-    // Create file path
-    file = dir + '/' + file;
-    stat = fs.statSync(file);
-    // If it's a directory, go through this process again
-    if (stat && stat.isDirectory()) {
-      walkSync(file, function(err, res) {
-        results = results.concat(res);
+  try {
+    list = fs.readdirSync(dir);
+    (function next() {
+      // Get next file
+      file = list[i++];
+      // No more files
+      if (!file) {
+        done(null, results);
+        return results;
+      }
+      // Create file path
+      file = dir + '/' + file;
+      stat = fs.statSync(file);
+      // If it's a directory, go through this process again
+      if (stat && stat.isDirectory()) {
+        walkSync(file, function(err, res) {
+          results = results.concat(res);
+          next();
+        });
+        // If not, just
+      } else {
+        results.push(file);
         next();
-      });
-    // If not, just
-    } else {
-      results.push(file);
-      next();
-    }
-  })();
+      }
+    })();
+  } catch (e) {
+    // One of the directory types doesn't exist. Just skip it.
+  }
 };
 
 /**

--- a/test/dyson.defaults.spec.js
+++ b/test/dyson.defaults.spec.js
@@ -1,4 +1,5 @@
 var request = require('supertest'),
+    should = require('should'),
     defaults = require('../lib/defaults');
 
 describe('dyson.config.defaults', function() {

--- a/test/dyson.loader.spec.js
+++ b/test/dyson.loader.spec.js
@@ -10,7 +10,7 @@ describe('dyson.config.loader', function() {
 
             var configs = loader.load(configDir);
 
-            configs.should.be.an.Object.and.have.keys('delete', 'get', 'post', 'put');
+            configs.should.be.an.Object.and.have.keys('delete', 'get', 'post', 'put', 'patch');
 
             configs.get[0].should.have.property('path');
 


### PR DESCRIPTION
I'm using Dyson for a project on which I've been working. We rely fairly heavily on PATCH requests. Since Dyson is built on Express, I figured it would be fairly easy to support PATCH requests, which did turn out to be the case.

This pull requests simply enables PATCH requests. I've also updated the tests to reflect this. The defaults test appeared to be missing a reference to should.js, which I've included. All tests pass, and PATCH requests seem to be working fine.

I've also added in support multiple directories holding the defined endpoints. For example, the following will now work.

-- get/
---- endpoint.js
---- sub/
------ endpoint-two.js

Both endpoint.js and endpoint-two.js will now be registered as endpoints.