### PR TITLE
Prevent bodyParser from consuming the request stream before proxying

### DIFF
--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -63,8 +63,11 @@ var registerServices = function(app, options, configs) {
             } else {
                 util.log('Registering', method.toUpperCase(), 'service at', config.path);
                 app[method](config.path, function(req, res, next) {
-                    middleware(req, res, requireParameter.bind(config))
+                    middleware(req, res, function() {
+                        requireParameter.call(config, req, res, next);
+                    });
                 }, config.callback, config.render);
+                app.options(config.path, cors({origin: true, credentials: true}));
             }
 
         });

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -37,11 +37,6 @@ var initExpress = function(port) {
 
     var app = express();
 
-    app.use(favicon(__dirname + '/favicon.ico'));
-    app.use(bodyParser.json());
-    app.use(bodyParser.urlencoded({ extended: true }));
-    app.use(cookieParser());
-    app.use(cors({origin: true, credentials: true}));
     app.listen(port);
 
     return app;
@@ -50,6 +45,13 @@ var initExpress = function(port) {
 // Register middleware to Express as service for each config (as in: `app.get(config.path, config.callback);`)
 
 var registerServices = function(app, options, configs) {
+    
+    var middleware = express();
+    middleware.use(favicon(__dirname + '/favicon.ico'));
+    middleware.use(bodyParser.json());
+    middleware.use(bodyParser.urlencoded({ extended: true }));
+    middleware.use(cookieParser());
+    middleware.use(cors({origin: true, credentials: true}));
 
     for(var method in configs) {
 
@@ -60,7 +62,9 @@ var registerServices = function(app, options, configs) {
                 util.log('Proxying', method.toUpperCase(), 'service at', config.path);
             } else {
                 util.log('Registering', method.toUpperCase(), 'service at', config.path);
-                app[method](config.path, requireParameter.bind(config), config.callback, config.render);
+                app[method](config.path, function(req, res, next) {
+                    middleware(req, res, requireParameter.bind(config))
+                }, config.callback, config.render);
             }
 
         });

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -4,6 +4,7 @@ var path = require('path'),
     bodyParser = require('body-parser'),
     cookieParser = require('cookie-parser'),
     cors = require('cors'),
+    rawBody = require('./raw-body'),
     loader = require('./loader'),
     defaults = require('./defaults'),
     proxy = require('./proxy'),
@@ -47,6 +48,7 @@ var initExpress = function(port) {
 var registerServices = function(app, options, configs) {
     
     var middleware = express();
+    middleware.use(rawBody());
     middleware.use(favicon(__dirname + '/favicon.ico'));
     middleware.use(bodyParser.json());
     middleware.use(bodyParser.urlencoded({ extended: true }));

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -5,12 +5,11 @@ var proxyMiddleware = function(req, res) {
 
     var proxyHost = util.options.get('proxyHost'),
         proxyPort = util.options.get('proxyPort'),
-        proxyURI = proxyHost + (proxyPort ? ':' + proxyPort : '') + req.url,
-        method = (req.method === 'DELETE' ? 'DEL' : req.method).toLowerCase();
+        proxyURI = proxyHost + (proxyPort ? ':' + proxyPort : '') + req.url;
 
     util.log('Proxying', req.url, 'to', proxyURI);
 
-    req.pipe(request[method](proxyURI, function(error) {
+    req.pipe(request({url: proxyURI}, function(error) {
         if(error) {
             util.error('500 INTERNAL SERVER ERROR:', proxyURI);
             res.writeHead(500);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -9,13 +9,28 @@ var proxyMiddleware = function(req, res) {
 
     util.log('Proxying', req.url, 'to', proxyURI);
 
-    req.pipe(request({url: proxyURI}, function(error) {
+    var stream;
+    if (req._body) {
+        stream = new require('stream').Readable();
+        stream._read = function(size) {
+            this.push(req.rawBody);
+            this.push(null);
+        };
+    } else {
+        stream = req;
+    }
+
+    stream.pipe(request({
+        method: req.method,
+        url: proxyURI,
+        headers: req.headers
+    }, function(error) {
         if(error) {
             util.error('500 INTERNAL SERVER ERROR:', proxyURI);
             res.writeHead(500);
             res.end();
         }
-    })).pipe(res);
+    })).pipe(res)
 };
 
 module.exports = {

--- a/lib/raw-body.js
+++ b/lib/raw-body.js
@@ -1,0 +1,14 @@
+
+module.exports = function(options) {
+  var propName = options && options.property || 'rawBody';
+  return function(req, res, next) {
+    var data = '';
+    req.on('data', function(chunk) {
+      data += chunk;
+    });
+    req.on('end', function() {
+      req[propName] = data;
+    });
+    next();
+  };
+};

--- a/test/dyson.integration.js
+++ b/test/dyson.integration.js
@@ -156,7 +156,7 @@ describe('dyson', function() {
 
         it('should respond with a 204 for an OPTIONS request', function(done) {
 
-            request(app).options('/').expect(204).end(function(err, res) {
+            request(app).options('/cache').expect(204).end(function(err, res) {
                 res.headers['access-control-allow-methods'].should.equal('GET,HEAD,PUT,PATCH,POST,DELETE');
                 res.headers['access-control-allow-credentials'].should.equal('true');
                 // The next actual value is 'undefined', should be req.header('Origin') (probably an issue with supertest)


### PR DESCRIPTION
When a request with some body content is proxied by dyson, it hangs forever because the bodyParser middleware has already consumed the stream (and so nothing is piped to `request` in the proxy).

The solution I found is to attach the dyson's middleware to the routes that it will effectively serve only.