### PR TITLE
Option to expose request to templates

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -7,18 +7,19 @@ var cache = {};
 
 var generate = function(req, res, next) {
 
+    // @todo rixo test exposeRequest
     var service = this,
         path = req.url,
-        params = req.params,
-        query = req.query;
-    
-    var templateArgs = [
-        req.params,
-        req.query,
-        req.body,
-        req.cookies,
-        req.headers
-    ];
+        exposeRequest = service.exposeRequest
+            || util.options.get('exposeRequest') && service.exposeRequest !== false;
+
+    var templateArgs = exposeRequest
+        ? [req]
+        : [req.params, req.query, req.body, req.cookies, req.headers];
+
+    var containerArgs = exposeRequest
+        ? [req]
+        : [req.params, req.query, req.data];
 
     if(_.isFunction(service.status)) {
         service.status.apply(service, arguments);
@@ -46,7 +47,7 @@ var generate = function(req, res, next) {
             }
 
             promise.then(function(data) {
-                return !service.container ? data : setValues(_.result(service, 'container'), [params, query, data], service);
+                return !service.container ? data : setValues(_.result(service, 'container'), containerArgs, service);
             }).then(function(data) {
                 res.body = cache[path] = data;
                 util.log('Resolving response for', req.method, path);

--- a/lib/response.js
+++ b/lib/response.js
@@ -10,9 +10,15 @@ var generate = function(req, res, next) {
     var service = this,
         path = req.url,
         params = req.params,
-        query = req.query,
-        body = req.body,
-        cookies = req.cookies;
+        query = req.query;
+    
+    var templateArgs = [
+        req.params,
+        req.query,
+        req.body,
+        req.cookies,
+        req.headers
+    ];
 
     if(_.isFunction(service.status)) {
         service.status.apply(service, arguments);
@@ -22,20 +28,20 @@ var generate = function(req, res, next) {
 
         if(!multiRequest.isMultiRequest(path)) {
 
-            var isCollection = _.isFunction(service.collection) ? service.collection.apply(service, [params, query, body, cookies]) : service.collection,
-                template = _.isFunction(service.template) ? service.template.apply(service, [params, query, body, cookies]) : service.template,
+            var isCollection = _.isFunction(service.collection) ? service.collection.apply(service, templateArgs) : service.collection,
+                template = _.isFunction(service.template) ? service.template.apply(service, templateArgs) : service.template,
                 promise;
 
             if(!isCollection) {
 
-                promise = setValues(template, [params, query, body, cookies]);
+                promise = setValues(template, templateArgs);
 
             } else {
 
-                var size = _.isFunction(service.size) ? service.size.apply(service, [params, query, body, cookies]) : service.size;
+                var size = _.isFunction(service.size) ? service.size.apply(service, templateArgs) : service.size;
 
                 promise = when.map(_.times(parseInt(size, 10)), function() {
-                    return setValues(template, [params, query, body, cookies]);
+                    return setValues(template, templateArgs);
                 });
             }
 


### PR DESCRIPTION
As discussed in issue [#44](https://github.com/webpro/dyson/issues/44):

- Adds an option `exposeRequest` that can be set globally and overridden at service definition level.

- When the option is not used, I've added request headers to the params that are provided to the template functions (which was the original purpose in the issue).

I've added tests for the option, but I'm not too confident that I've put them in the right place. Tell me what you think when you review.