### PR TITLE
Fix type verification to avoid null variables

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -19,7 +19,7 @@ var load = function(configDir) {
 function findRecursive(obj, method) {
     var configs = [];
     for(var key in obj) {
-        if(typeof obj[key] === 'object') {
+        if(_.isObject(obj[key])) {
             if('path' in obj[key]) {
                 if(obj.__method === method || (obj[key].method && obj[key].method.toLowerCase() === method)) {
                     configs.push(obj[key]);


### PR DESCRIPTION
`typeof null` in js is `object`. This fix avoid this weird behavior https://github.com/webpro/dyson/issues/54