### PR TITLE
Add options to configure bodyParser's limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Optionally, you can put a `dyson.json` file next to the configuration folders (i
 ```
 
 * Setting `multiRequest` to `false` disables the [combined requests](#combined-requests) feature.
+* Setting `bodyParserJsonLimit` or `bodyParserUrlencodedLimit` to `1mb` increases the limit to 1mb from the bodyParser's default of 100kb.
 * By default, the `proxy` is set to `false`
 
 ## Development & run tests

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -51,8 +51,16 @@ var registerServices = function(app, options, configs) {
     var request = express();
     request.use(rawBody());
     request.use(favicon(__dirname + '/favicon.ico'));
-    request.use(bodyParser.json());
-    request.use(bodyParser.urlencoded({extended: true}));
+    if(options.bodyParserJsonLimit) {
+        request.use(bodyParser.json({limit: options.bodyParserJsonLimit}));
+    } else {
+        request.use(bodyParser.json());
+    }
+    if(options.bodyParserUrlencodedLimit) {
+        request.use(bodyParser.urlencoded({limit: options.bodyParserUrlencodedLimit, extended: true}));
+    } else {
+        request.use(bodyParser.urlencoded({extended: true}));
+    }
     request.use(cookieParser());
     request.use(cors({origin: true, credentials: true}));
 


### PR DESCRIPTION
Two option params are added: bodyParserJsonLimit and bodyParserUrlencodedLimit.
bodyParser's limit is 100kb and sometimes you need fake a endpoint that accepts more than that.
This is to fix #62 