### PR TITLE
HTTPS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,25 @@ Override the `render` method of the Express middleware in the endpoint definitio
 }
 ```
 
+## HTTPS
+
+If you want to run dyson over https:// you have to provide a self-signed (or authority-signed) certificate into the `options.https` the same way it's required for NodeJS HTTPS to work:
+
+``` javascript
+var fs = require('fs');
+
+dyson.bootstrap({
+	configDir: __dirname + '/dummy',
+	port: 3001,
+	https: {
+    		key: fs.readFileSync(__dirname + '/certs/sample.key'),
+    		crt: fs.readFileSync(__dirname + '/certs/sample.crt')
+	}
+});
+```
+
+*Note*: if running HTTPS on port 443, it will require `sudo` privileges.
+
 ## Installation
 
 The recommended way to install dyson is to install it locally and put it in your `package.json`:

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -29,17 +29,21 @@ var bootstrap = function(options) {
 
     var configs = defaults.assignToAll(rawConfigs);
 
-    var app = initExpress(options.port);
+    var app = initExpress(options.port, options.https);
 
     registerServices(app, options, configs);
 
 };
 
-var initExpress = function(port) {
-
+var initExpress = function(port, secureOptions) {
+    
     var app = express();
-
-    app.listen(port);
+    
+    if (secureOptions) {
+        require('https').createServer(secureOptions, app).listen(port);
+    } else {
+        app.listen(port);
+    }
 
     return app;
 };


### PR DESCRIPTION
I don't know how to create the proper test. I've tried:

```javascript
        before(function () {
            var sampleCrt = require('fs').readFileSync(__dirname + '/certs/sample.crt'),
                sampleKey = require('fs').readFileSync(__dirname + '/certs/sample.key');

            dyson.bootstrap({
                configDir: __dirname + '/dummy',
                port: 8001,
                https: {
                    key: sampleKey,
                    crt: sampleCrt
                }
            });
        });

        it('should respond on https protocol', function (done) {
            request(app).get('/dummy/1').expect(200, {}, done);
        });
```

but I'm getting a 404 instead of the expected 200, for whatever reason.

Doesn't break any current test anyway.