### PR TITLE
Add watch switch

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 const dyson = require('./dyson'),
+  response = require('./response'),
   pkg = require('../package.json'),
   _ = require('lodash'),
   fs = require('fs'),
@@ -60,6 +61,7 @@ const startDyson = opts => {
     dysonApp = null;
 
     clearRequire.match(new RegExp('^' + _.escapeRegExp(opts.configDir)));
+    response.clearCache();
   }
 
   fs.stat(opts.configDir, (error, stats) => {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -32,7 +32,7 @@ const execute = options => {
 
     if(watch) {
       const eventsToWatch = ['add', 'change', 'unlink', 'unlinkDir'];
-      const watcher = chokidar.watch(path.join(opts.configDir, '**/*.js'), {persistent: true});
+      const watcher = chokidar.watch(opts.configDir);
       watcher.on('raw', (event) => {
         if(eventsToWatch.indexOf(event) > -1) {
           startDyson(opts);
@@ -57,9 +57,9 @@ const startDyson = opts => {
     console.info('Restarting Dyson...');
     let server = dysonApp.get('dyson_server');
     server.destroy();
-
     dysonApp = null;
-    clearRequire.all();
+
+    clearRequire.match(new RegExp('^' + _.escapeRegExp(opts.configDir)));
   }
 
   fs.stat(opts.configDir, (error, stats) => {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,11 +3,19 @@ const dyson = require('./dyson'),
   pkg = require('../package.json'),
   _ = require('lodash'),
   fs = require('fs'),
-  path = require('path');
+  path = require('path'),
+  chokidar = require('chokidar'),
+  clearRequire = require('clear-require');
+
+let isStarting, dysonApp;
 
 const execute = options => {
-
   if(options.length) {
+    const watchIndex = options.indexOf('--watch');
+    const watch = watchIndex > -1;
+    if(watch) {
+      options.splice(watchIndex, 1);
+    }
 
     const [ dir, port ] = options;
 
@@ -16,23 +24,55 @@ const execute = options => {
       configDir: dir,
       proxy: false,
       multiRequest: ',',
-      quiet: false
+      quiet: false,
+      watch: watch
     });
 
     opts.configDir = path.resolve(opts.configDir);
 
-    fs.stat(opts.configDir, (error, stats) => {
-      if(!error && stats.isDirectory()) {
-        dyson.bootstrap(opts);
-        console.info(`Dyson listening at port: ${opts.port}`);
-      } else {
-        console.error(`Directory does not exist: ${opts.configDir}`);
-      }
-    });
+    if(watch) {
+      const eventsToWatch = ['add', 'change', 'unlink', 'unlinkDir'];
+      const watcher = chokidar.watch(path.join(opts.configDir, '**/*.js'), {persistent: true});
+      watcher.on('raw', (event) => {
+        if(eventsToWatch.indexOf(event) > -1) {
+          startDyson(opts);
+        }
+      });
+    }
 
+    startDyson(opts);
   } else {
     showHelp();
   }
+};
+
+const startDyson = opts => {
+  if(isStarting) {
+    return;
+  }
+
+  isStarting = true;
+
+  if(dysonApp) {
+    console.info('Restarting Dyson...');
+    let server = dysonApp.get('dyson_server');
+    server.destroy();
+
+    dysonApp = null;
+    clearRequire.all();
+  }
+
+  fs.stat(opts.configDir, (error, stats) => {
+    if(!error && stats.isDirectory()) {
+      dysonApp = dyson.bootstrap(opts);
+      const watchingInfo = (opts.watch ? ' (watching)' : '');
+      console.info(`Dyson listening at port: ${opts.port}${watchingInfo}`);
+    } else {
+      console.error(`Directory does not exist: ${opts.configDir}`);
+    }
+
+    isStarting = false;
+  });
 };
 
 const readOptions = configDir => {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,7 +5,7 @@ const dyson = require('./dyson'),
   _ = require('lodash'),
   fs = require('fs'),
   path = require('path'),
-  chokidar = require('chokidar'),
+  watchr = require('watchr'),
   clearRequire = require('clear-require');
 
 let isStarting, dysonApp;
@@ -32,12 +32,8 @@ const execute = options => {
     opts.configDir = path.resolve(opts.configDir);
 
     if(watch) {
-      const eventsToWatch = ['add', 'change', 'unlink', 'unlinkDir'];
-      const watcher = chokidar.watch(opts.configDir);
-      watcher.on('raw', (event) => {
-        if(eventsToWatch.indexOf(event) > -1) {
-          startDyson(opts);
-        }
+      watchr.open(opts.configDir, function() {
+        startDyson(opts);
       });
     }
 

--- a/lib/dyson.js
+++ b/lib/dyson.js
@@ -4,6 +4,7 @@ const https = require('https'),
   bodyParser = require('body-parser'),
   cookieParser = require('cookie-parser'),
   cors = require('cors'),
+  enableDestroy = require('server-destroy'),
   rawBody = require('./raw-body'),
   loader = require('./loader'),
   defaults = require('./defaults'),
@@ -41,6 +42,7 @@ const createServer = options => {
     server = app.listen(options.port);
   }
 
+  enableDestroy(server);
   app.set('dyson_server', server);
   return app;
 };

--- a/lib/response.js
+++ b/lib/response.js
@@ -3,7 +3,7 @@ const multiRequest = require('./multiRequest'),
   _ = require('lodash'),
   when = require('when');
 
-const cache = {};
+let cache = {};
 
 const generate = (req, res, next) => {
 
@@ -77,8 +77,13 @@ const render = (req, res) => {
   res.send(res.body);
 };
 
+const clearCache = () => {
+  cache = {};
+};
+
 module.exports = {
   generate,
   render,
-  setValues
+  setValues,
+  clearCache
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "dependencies": {
     "body-parser": "1.17.2",
+    "chokidar": "^1.7.0",
+    "clear-require": "^2.0.0",
     "cookie-parser": "1.4.3",
     "cors": "2.8.3",
     "express": "4.15.3",
@@ -32,6 +34,7 @@
     "request": "2.79.0",
     "require-directory": "2.1.1",
     "serve-favicon": "2.4.3",
+    "server-destroy": "^1.0.1",
     "when": "3.7.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "body-parser": "1.17.2",
-    "chokidar": "^1.7.0",
     "clear-require": "^2.0.0",
     "cookie-parser": "1.4.3",
     "cors": "2.8.3",
@@ -35,6 +34,7 @@
     "require-directory": "2.1.1",
     "serve-favicon": "2.4.3",
     "server-destroy": "^1.0.1",
+    "watchr": "^3.0.1",
     "when": "3.7.8"
   },
   "devDependencies": {


### PR DESCRIPTION
This satisfies #81 

I started with chokidar for file change detection but was still getting dupe events quite a bit with multiple editors. So, after reading [an issue](https://github.com/bevry/watchr/issues/33#issuecomment-183511327) that was solved by an alternative, I switched to watchr and it works very well with its 2-second default delay. You can see the chokidar attempt in the history if you prefer it and want to tweak it to see if you can get it working. I tried Sublime Text 3, Notepad++, and VS Code to test atomic edits.

This was a little trickier than I originally thought due to the config files being cached by require. clear-require made short work of that with a simple regex to clear the require cache for configs. Additionally, the server wasn't closing with some browsers hitting endpoints. Even though browsers aren't the typical consumer for an API, I used server-destroy to solve the problem.

Lastly, the response cache proved problematic even with the cleared configs. So, I surfaced a function to clear it and all was well.

I couldn't see an easy way to write a test for this feature. I'll think some more on maybe starting a process with the CLI command necessary, making config changes, then seeing endpoints change. That's a bit more involved than I have time for just now.