### PR TITLE
Bumping version of serve-favicon to resolve npm audit warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lodash": "4.17.4",
     "request": "2.81.0",
     "require-directory": "2.1.1",
-    "serve-favicon": "2.4.3"
+    "serve-favicon": "2.4.5"
   },
   "devDependencies": {
     "@babel/plugin-syntax-object-rest-spread": "7.0.0-beta.32",


### PR DESCRIPTION
Running `npm audit` in my project gives the following output:
```┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ fresh                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ dyson [dev]                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ dyson > serve-favicon > fresh                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/526                       │
└───────────────┴──────────────────────────────────────────────────────────────┘```