### PR TITLE
Fix: only cache response if they have the same method & patch

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -10,20 +10,21 @@ const generate = (req, res, next) => {
   const options = res.app.get('dyson_options');
   const { log } = res.app.get('dyson_logger');
   const path = req.url;
+  const cacheKey = req.method + req.url;
   const exposeRequest = config.exposeRequest || (options.exposeRequest && config.exposeRequest !== false);
 
   const templateArgs = exposeRequest ? [req] : [req.params, req.query, req.body, req.cookies, req.headers];
   const containerArgs = exposeRequest ? [req] : [req.params, req.query];
 
-  if (config.cache && cache[path]) {
+  if (config.cache && cache[cacheKey]) {
     log('Resolving response for', req.method, path, '(cached)');
-    res.body = cache[path];
+    res.body = cache[cacheKey];
     return next();
   }
 
   if (multiRequest.isMultiRequest(path, options)) {
     Promise.all(multiRequest.doMultiRequest(req, path)).then(data => {
-      res.body = cache[path] = data;
+      res.body = cache[cacheKey] = data;
       log('Resolving response for:', req.method, path, '(multiRequest)');
       next();
     });
@@ -45,7 +46,7 @@ const generate = (req, res, next) => {
         : assembleResponse(_.result(config, 'container'), [...containerArgs, response], config)
     )
     .then(data => {
-      res.body = cache[path] = data;
+      res.body = cache[cacheKey] = data;
       log('Resolving response for', req.method, path);
       next();
     });

--- a/test/config.js
+++ b/test/config.js
@@ -19,6 +19,34 @@ test('should return cached response', async t => {
   t.deepEqual(cachedRes.body, res.body);
 });
 
+test('should not cache the response with a different method', async t => {
+  let id = 0;
+  const app = getService([
+    {
+      path: '/cache',
+      cache: false,
+      method: 'GET',
+      template: {
+        id: () => id++
+      }
+    },
+    {
+      path: '/cache',
+      cache: false,
+      method: 'POST',
+      template: {
+        id: () => id++
+      }
+    }
+  ]);
+
+  const res = await request(app).get('/cache');
+  const cachedRes = await request(app).post('/cache');
+
+  t.is(cachedRes.status, 200);
+  t.notDeepEqual(cachedRes.body, res.body);
+});
+
 test('should return uncached response', async t => {
   let id = 0;
   const app = getService({


### PR DESCRIPTION
Currently the cache is based only on the path of the request

So, if during processing there are 2 calls with a different method the cache does not allow to have a different response

The changes add the method in the cache key